### PR TITLE
fix: Correction du nombre d'heures d'ITC en MPSI option SI

### DIFF
--- a/content/posts/mp2i_ou_mpsi.md
+++ b/content/posts/mp2i_ou_mpsi.md
@@ -56,7 +56,7 @@ Un professeur de Physique en CPGE vous met à disposition un récapitulatif des 
 | **MPSI** | I | 12 | 6 | 2 | 0 | 1.5 | 2 | 2 | 2 | 0 |
 | 〃 | II (Info) | 12 | 6 | 2 | 0 | 4 | 0 | 2 | 2 | 2 |
 | 〃 | II (SI légère) | 12 | 6 | 2 | 0 | 2 | 2 | 2 | 2 | 2 |
-| 〃 | II (SI renforcée) | 12 | 6 | 2 | 0 | 0 | 4 | 2 | 2 | 2 |
+| 〃 | II (SI renforcée) | 12 | 6 | 2 | 0 | 2 | 4 | 2 | 2 | 2 |
 
 *À noter que les heures de Physique et de Chimie ne sont pas distinguées en MPSI.*
 


### PR DESCRIPTION
Le nombre d'heures d'Informatique de Tronc Commun est de 2h (et non 0) en MPSI option SI (renforcée).

Erreur signalée sur [Discord](https://discord.com/channels/872138069594214410/911609939728949309/1379904298476900372) par BP.