### PR TITLE
Suppression Google Analytics

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -101,13 +101,6 @@ enableEmoji = true
     [params.page.share]
       enable = false
 
-  [params.analytics]
-    enable = true
-    # Google Analytics
-    [params.analytics.google]
-      id = "G-7SXBL516N1"  # add your tracking id
-      anonymizeIP = false
-
   [params.cookieconsent]
     enable = false
 

--- a/content/mentions-legales.md
+++ b/content/mentions-legales.md
@@ -31,5 +31,4 @@ En cas de panne ou de défaillance, le service [Cloudflare](https://www.cloudfla
 
 ## ARTICLE 4 - COLLECTE DES DONNEES
 
-Le site assure à l'utilisateur une collecte et un traitement d'informations personnelles dans le respect de la vie privée conformément à la loi n°78-17 du 6 janvier 1978 relative à l'informatique, aux fichiers et aux libertés.
-
+Le site n'effectue aucune collecte de données.

--- a/content/mentions-legales.md
+++ b/content/mentions-legales.md
@@ -33,4 +33,3 @@ En cas de panne ou de défaillance, le service [Cloudflare](https://www.cloudfla
 
 Le site assure à l'utilisateur une collecte et un traitement d'informations personnelles dans le respect de la vie privée conformément à la loi n°78-17 du 6 janvier 1978 relative à l'informatique, aux fichiers et aux libertés.
 
-A savoir, les données collectées sont anonymes et utilisées uniquement à des fins d'analyse par le service [Google Analytics](https://analytics.google.com/).

--- a/layouts/partials/head/meta.html
+++ b/layouts/partials/head/meta.html
@@ -1,9 +1,5 @@
 {{- $params := .Scratch.Get "params" -}}
 
-<!-- Google Analytics -->
-{{- partial "plugin/analytics.html" . -}}
-<!-- End of Google Analytics -->
-
 <!-- Default meta.html content -->
 <meta name="description" content="{{ .Site.Params.description }}">
 <meta property="og:type" content='{{ if eq .Section "posts" }}article{{ else }}website{{ end }}'>


### PR DESCRIPTION
Google Analytics est toujours relié à l'ancien site dont les accès sont gardés par une seule personne ne souhaitant pas les partager. De plus, les données n'étaient pas réellement anonymisées de par l'option `anonymizeIP` à `false`. Enfin une solution plus respectueuse de la vie privée pourrait remplacer à terme Google Analytics.