### PR TITLE
Donner une couleur spécifique aux éléments accentués en mode sombre

### DIFF
--- a/assets/css/_override.scss
+++ b/assets/css/_override.scss
@@ -2,3 +2,4 @@ $global-font-color-dark: #dbd0d0 !important;
 $global-background-color-dark: #2A2A2C !important;
 $global-font-secondary-color-dark: #93939b !important;
 $global-link-color-dark: #c1c1cf !important;
+$single-link-color-dark: #C76C4A !important;


### PR DESCRIPTION
En mode sombre les liens et autres éléments accentués prennent actuellement la couleur des "menu-items" (Filière, Informatique, Concours...) ce qui les rend assez difficilement lisibles dans le texte (voir captures d'écran).
Cette pull request leur permet d'avoir une couleur facilement distinguable, j'ai choisi cette teinte car elle correspond à la couleur d'accent du mode clair inversée à 83.14% (c'est, il me semble, ce qui est fait dans le cas général (à en croire  [_custom.scss](https://github.com/prepas-mpi/prepas-mp2i.org/blob/develop/assets/css/_custom.scss)) donc j'ai choisi de garder cette cohérence).

La page [Concours](https://prepas-mp2i.org/concours/) actuellement:

<img width="1919" height="960" alt="image" src="https://github.com/user-attachments/assets/a20450fc-d37e-42b6-b184-34783785de1b" />


La page [Concours](https://prepas-mp2i.org/concours/) avec la couleur d'accent modifiée:

<img width="1920" height="958" alt="image" src="https://github.com/user-attachments/assets/dccf22fd-8efb-4e24-ba00-7e7b05d35a57" />
