### PR TITLE
Ajout d'une page pour présenter le forum des grandes écoles

### DIFF
--- a/content/posts/forum-grandes-ecoles-2025.md
+++ b/content/posts/forum-grandes-ecoles-2025.md
@@ -24,7 +24,7 @@ De la même façon que le forum dédié à renseigner les lycéen(ne)s sur la MP
 
 Ce forum a pris place le 20 Juillet 2025, de 15h à 17h+.
 
-Cette première édition a eue lieu intégralement sur [discord](https://discord.prepas-mp2i.org) et était séparée en 4 stands distincts:
+Cette première édition a eu lieu intégralement sur [discord](https://discord.prepas-mp2i.org) et était séparée en 4 stands distincts:
 - Le stand ENS
 - Le stand Polytechnique/Centrale/Ponts
 - Le stand Mines-Télécom

--- a/content/posts/forum-grandes-ecoles-2025.md
+++ b/content/posts/forum-grandes-ecoles-2025.md
@@ -1,0 +1,43 @@
+---
+title: Forum Grandes Écoles 2025
+slug: forum-grandes-ecoles-2025
+date: 2025-07-28T20:11:00+01:00
+author: Milan, Nozaé
+summary: Page de présentation du forum des grandes écoles 2025. Vous y trouverez toutes les informations concernant le forum des écoles intégrables après une filière MPI-MP2I, édition 2025.
+tags:
+    - préparationnaires
+categories:
+    - Évènements
+draft: true
+---
+
+{{< admonition info "Forum terminé" >}}
+Le forum des Grandes Écoles 2025 est terminé ! Cette année, quelques dizaines de préparationnaires ont pu être informés grâce au forum ! {{< newline >}}.
+Vous pouvez aussi faire un retour sur l'évenement en temps que spectateur [ici](https://forms.gle/GB5bBJwAM7fjqr9h8).
+{{< /admonition >}}
+
+## Présentation
+
+De la même façon que le forum dédié à renseigner les lycéen(ne)s sur la MP2I/MPI, le forum des Grandes Écoles a pour but de renseigner nos chères bêtes de concours sur ce qui peut les attendre pour la suite.
+
+## Organisation
+
+Ce forum a pris place le 20 Juillet 2025, de 15h à 17h+.
+
+Cette première édition a eue lieu intégralement sur [discord](https://discord.prepas-mp2i.org) et était séparée en 4 stands distincts:
+- Le stand ENS
+- Le stand Polytechnique/Centrale/Ponts
+- Le stand Mines-Télécom
+- Le stand CCINP/E3A/Autres
+
+## Intervenants
+
+Cette année, 19 écoles ont participé au forum ! Vous trouverez ci-dessous la liste des 22 intervenants et intervenantes qui ont aidé à leur présentation :
+
+| ENS Ulm | ENS Lyon | ENS Lyon | ENS Paris Saclay | Polytechnique (X) | Centrale Supélec | Mines de Paris | ENSTA Paris | Télécom SudParis | Télécom Nancy | Télécom Nancy | EURECOM | ENSIIE | ENSIIE | ENS Géomatique | ENSIMAG | ENSAI Rennes | ESISAR | CY Tech | INSA Toulouse | ENSIBS | emlyon |
+|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:---:|:---:|:---:|
+| Antoine | Elouan | Vivien | Alaska | François-Xavier | Mrtn | Nathan | Théo | Triw | Ganda | Ely | H3xerty | Agryos | Nicolas | Emma (son copain) | Joachim | Maxime | Eros | Chat_Vert | Alain | Margaux | Jeremy |
+
+## Forums précédents
+
+Vous pouvez retrouver la liste de tous les forums et autres événements sur [cette page](/categories/%C3%A9v%C3%A8nements/).

--- a/content/posts/forum-grandes-ecoles-2025.md
+++ b/content/posts/forum-grandes-ecoles-2025.md
@@ -10,7 +10,7 @@ categories:
     - Évènements
 ---
 
-{{< admonition warning "Forum MP2I" >}}
+{{< admonition warning "Forum MP2I/MPI" >}}
 Cette page concerne le forum **des Grandes Écoles** accessibles après une MPI, destiné premièrement aux préparationnaires.
 Si vous êtes au lycée et que vous êtes intéressés par la MP2I, les informations concernant le forum de la filière sont disponibles sur [cette page](/forum).
 {{< /admonition >}}

--- a/content/posts/forum-grandes-ecoles-2025.md
+++ b/content/posts/forum-grandes-ecoles-2025.md
@@ -10,6 +10,11 @@ categories:
     - Évènements
 ---
 
+{{< admonition warning "Forum MP2I" >}}
+Cette page concerne le forum **des Grandes Écoles** accessibles après une MPI, destiné premièrement aux préparationnaires.
+Si vous êtes au lycée et que vous êtes intéressé par la MP2I, les informations concernant le forum de la filière sont disponibles sur [cette page](/forum).
+{{< /admonition >}}
+
 {{< admonition info "Forum terminé" >}}
 Le forum des Grandes Écoles 2025 est terminé ! Cette année, une soixantaine de préparationnaires a pu être informée grâce au forum ! {{< newline >}}
 Vous pouvez aussi faire un retour sur l'événement en temps que spectateur [ici](https://forms.gle/GB5bBJwAM7fjqr9h8).

--- a/content/posts/forum-grandes-ecoles-2025.md
+++ b/content/posts/forum-grandes-ecoles-2025.md
@@ -12,7 +12,7 @@ draft: true
 ---
 
 {{< admonition info "Forum terminé" >}}
-Le forum des Grandes Écoles 2025 est terminé ! Cette année, quelques dizaines de préparationnaires ont pu être informés grâce au forum ! {{< newline >}}.
+Le forum des Grandes Écoles 2025 est terminé ! Cette année, quelques dizaines de préparationnaires ont pu être informés grâce au forum ! {{< newline >}}
 Vous pouvez aussi faire un retour sur l'évenement en temps que spectateur [ici](https://forms.gle/GB5bBJwAM7fjqr9h8).
 {{< /admonition >}}
 

--- a/content/posts/forum-grandes-ecoles-2025.md
+++ b/content/posts/forum-grandes-ecoles-2025.md
@@ -12,7 +12,7 @@ categories:
 
 {{< admonition warning "Forum MP2I" >}}
 Cette page concerne le forum **des Grandes Écoles** accessibles après une MPI, destiné premièrement aux préparationnaires.
-Si vous êtes au lycée et que vous êtes intéressé par la MP2I, les informations concernant le forum de la filière sont disponibles sur [cette page](/forum).
+Si vous êtes au lycée et que vous êtes intéressés par la MP2I, les informations concernant le forum de la filière sont disponibles sur [cette page](/forum).
 {{< /admonition >}}
 
 {{< admonition info "Forum terminé" >}}

--- a/content/posts/forum-grandes-ecoles-2025.md
+++ b/content/posts/forum-grandes-ecoles-2025.md
@@ -13,7 +13,7 @@ draft: true
 
 {{< admonition info "Forum terminé" >}}
 Le forum des Grandes Écoles 2025 est terminé ! Cette année, quelques dizaines de préparationnaires ont pu être informés grâce au forum ! {{< newline >}}
-Vous pouvez aussi faire un retour sur l'évenement en temps que spectateur [ici](https://forms.gle/GB5bBJwAM7fjqr9h8).
+Vous pouvez aussi faire un retour sur l'événement en temps que spectateur [ici](https://forms.gle/GB5bBJwAM7fjqr9h8).
 {{< /admonition >}}
 
 ## Présentation

--- a/content/posts/forum-grandes-ecoles-2025.md
+++ b/content/posts/forum-grandes-ecoles-2025.md
@@ -18,7 +18,7 @@ Vous pouvez aussi faire un retour sur l'événement en temps que spectateur [ici
 
 ## Présentation
 
-De la même façon que le forum dédié à renseigner les lycéen(ne)s sur la MP2I/MPI, le forum des Grandes Écoles a pour but de renseigner nos chères bêtes de concours sur ce qui peut les attendre pour la suite.
+De la même façon que le forum dédié à renseigner les lycéen(ne)s sur la MP2I/MPI, le forum des Grandes Écoles a pour but de renseigner les préparationnaires aux différents concours sur ce qui peut les attendre pour la suite.
 
 ## Organisation
 

--- a/content/posts/forum-grandes-ecoles-2025.md
+++ b/content/posts/forum-grandes-ecoles-2025.md
@@ -8,7 +8,6 @@ tags:
     - préparationnaires
 categories:
     - Évènements
-draft: true
 ---
 
 {{< admonition info "Forum terminé" >}}

--- a/content/posts/forum-grandes-ecoles-2025.md
+++ b/content/posts/forum-grandes-ecoles-2025.md
@@ -11,7 +11,7 @@ categories:
 ---
 
 {{< admonition info "Forum terminé" >}}
-Le forum des Grandes Écoles 2025 est terminé ! Cette année, quelques dizaines de préparationnaires ont pu être informés grâce au forum ! {{< newline >}}
+Le forum des Grandes Écoles 2025 est terminé ! Cette année, une soixantaine de préparationnaires a pu être informée grâce au forum ! {{< newline >}}
 Vous pouvez aussi faire un retour sur l'événement en temps que spectateur [ici](https://forms.gle/GB5bBJwAM7fjqr9h8).
 {{< /admonition >}}
 

--- a/content/posts/forum-grandes-ecoles-2025.md
+++ b/content/posts/forum-grandes-ecoles-2025.md
@@ -34,7 +34,7 @@ Cette première édition a eu lieu intégralement sur [discord](https://discord.
 
 Cette année, 19 écoles ont participé au forum ! Vous trouverez ci-dessous la liste des 22 intervenants et intervenantes qui ont aidé à leur présentation :
 
-| ENS Ulm | ENS Lyon | ENS Lyon | ENS Paris Saclay | Polytechnique (X) | Centrale Supélec | Mines de Paris | ENSTA Paris | Télécom SudParis | Télécom Nancy | Télécom Nancy | EURECOM | ENSIIE | ENSIIE | ENS Géomatique | ENSIMAG | ENSAI Rennes | ESISAR | CY Tech | INSA Toulouse | ENSIBS | emlyon |
+| ENS Ulm | ENS Lyon | ENS Lyon | ENS Paris Saclay | Polytechnique | Centrale Supélec | Mines de Paris | ENSTA Paris | Télécom SudParis | Télécom Nancy | Télécom Nancy | EURECOM | ENSIIE | ENSIIE | ENS Géomatique | ENSIMAG | ENSAI Rennes | ESISAR | CY Tech | INSA Toulouse | ENSIBS | EM Lyon |
 |:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:---:|:---:|:---:|
 | Antoine | Elouan | Vivien | Alaska | François-Xavier | Mrtn | Nathan | Théo | Triw | Ganda | Ely | H3xerty | Agryos | Nicolas | Emma (son copain) | Joachim | Maxime | Eros | Chat_Vert | Alain | Margaux | Jeremy |
 

--- a/content/posts/forum2025.md
+++ b/content/posts/forum2025.md
@@ -15,6 +15,11 @@ categories:
     - Évènements
 ---
 
+{{< admonition warning "Forum Grandes Écoles" >}}
+Cette page concerne le forum **de la filière MPI/MP2I**, destiné premièrement aux lycéens intéressés par la filière.
+Si vous êtes déjà en MP2I ou en MPI, les informations concernant le forum **des Grandes Écoles** sont disponibles sur [cette page](/posts/forum-grandes-ecoles-2025).
+{{< /admonition >}}
+
 {{< admonition info "Forum terminé" >}}
 Le forum 2025 est terminé ! Cette année, plus de 50 lycéens et parents d'élèves ont pu être informés grâce au forum ! {{< newline >}}
 Vous pouvez télécharger [le diaporama](/documents/forum/diaporama_2025.pdf) utilisé comme support en PDF. {{< newline >}}


### PR DESCRIPTION
Le 20 juillet 2025 la première édition du forum des grandes écoles a eue lieu sur le discord.

Ce commit propose la création d'une page dédiée à la présentation de ce forum, de façon analogue aux différentes pages sur le [forum des étudiants](https://prepas-mp2i.org/forum/).

J'ai utilisé les différents messages de Nozaé dans le canal "Annonce" du discord pour construire cette page (j'ai copié collé certains passages, je l'ai par conséquent intégrée aux auteurs).

Le post est marqué comme "draft" pour l'instant, n'hésitez pas à faire vos retours.