### PR TITLE
:bug: fix: met à jour les places ENSAI MPI fonctionnaire

### DIFF
--- a/content/posts/concours.md
+++ b/content/posts/concours.md
@@ -452,7 +452,7 @@ Les candidats passent uniquement les [épreuves orales du concours commun Mines-
 | [ENSIL-ENSCI Limoges]            | Mécatronique                                    |           2           |
 | 〃                               | Electronique et télécommunications              |           2           |
 | [ENSAI]                          | Civil                                           |           8           |
-| 〃                               | Fonctionnaire                                   |           2           |
+| 〃                               | Fonctionnaire                                   |           3           |
 | [CY-Tech Cergy-Pau]              | Informatique                                    |           6           |
 | 〃                               | Mathématiques appliquées                        |           4           |
 | [Clermont Auvergne INP - ISIMA]  |                                                 |          16           |


### PR DESCRIPTION
## Description

Correction du nombre de places ouvertes dans la filière fonctionnaire de l’ENSAI pour la voie MPI.

Cette mise à jour fait suite à la redistribution aux classes préparatoires scientifiques de places non pourvues au concours interne.

## Sources

* Webinaire d’information
* Confirmation par mail en interne
